### PR TITLE
Remove dependency on package:mock

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,4 +11,3 @@ dependencies:
   logging: '>=0.9.0'
 dev_dependencies:
   test: '>=0.12.13'
-  mock: '>=0.10.0'


### PR DESCRIPTION
It's not actually used.